### PR TITLE
Update navigation.html

### DIFF
--- a/layouts/partials/navigation.html
+++ b/layouts/partials/navigation.html
@@ -30,7 +30,7 @@
                         <ul class="navbar-nav ml-auto navigation-menu">
                                 <li class="nav-item"><a class="nav-link" data-scroll href="{{ $.Site.BaseURL }}#body">{{ with $.Site.Params.home | safeHTML }}{{ . }}{{ end }}</a></li>
                                 {{ range $.Site.Menus.nav }}
-                                <li class="nav-item"><a class="nav-link" data-scroll href="{{ $.Site.BaseURL }}{{ .URL }}">{{ .Pre }}{{ .Name }}</a></li>
+                                <li class="nav-item"><a class="nav-link" data-scroll href="{{ .URL }}">{{ .Pre }}{{ .Name }}</a></li>
                                 {{ end }}
                         </ul>
                 </div>


### PR DESCRIPTION
Links to external resources had psicode.org/ prepended to the url.   For example, on this page [installs](https://psicode.org/installs/v132/) the link to Docs is https://psicode.org/http://psicode.org/psi4manual/master/index.html