### PR TITLE
fix navigation when not on the main page

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -14,7 +14,7 @@ theme = "meghna-hugo"
     [[menu.nav]]
     name = "News"
     pre = "<i class='far fa-newspaper'></i>"
-    URL = "#portfolio"
+    URL = "/#portfolio"
     weight = 3
 
 #    [[menu.nav]]
@@ -32,14 +32,15 @@ theme = "meghna-hugo"
     [[menu.nav]]
     pre = "<i class='fas fa-arrow-alt-circle-down'></i>"
     name = "Downloads"
-    URL = "installs/latest"
+    URL = "/installs/latest/"
     weight = 8
 
     [[menu.nav]]
     identifier = "Manual"
     pre = "<i class='fa fa-book'></i>"
     name = "Docs"
-    URL = "http://psicode.org/psi4manual/master/index.html"
+    #URL = "http://psicode.org/psi4manual/master/index.html"
+    URL = "https://psi4manual.netlify.app/index.html"
     weight = 4
 
     [[menu.nav]]


### PR DESCRIPTION
this will point to the nightly docs in the nav bar but doesn't help all the psicode.org/psi4manual links exising over the years. those are still pointing to a certain snapshot in this repo.