### PR TITLE
release notes tile

### DIFF
--- a/data/portfolio.yml
+++ b/data/portfolio.yml
@@ -26,6 +26,12 @@ filterList :
 
 portfolioItem :
   - types: releases
+    image: https://dummyimage.com/400x300/f2f2f2/0011ff.jpg&text=Release+Notes
+    URL: https://github.com/psi4/psi4/releases
+    title: All Releases
+    description: GitHub Tagged Releases
+
+  - types: releases
     image : images/portfolio/fireworks_slide_v191.jpg
     URL : posts/v191
     title : v1.9.1 - February 2024


### PR DESCRIPTION
linked to https://github.com/psi4/psi4/releases but an alternate link would be https://psicode.org/categories/releases/